### PR TITLE
allow resque 2

### DIFF
--- a/cloudwatch-metrics-resque.gemspec
+++ b/cloudwatch-metrics-resque.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.4'
 
   spec.add_dependency 'aws-sdk-core', '~> 2'
-  spec.add_dependency 'resque', '~> 1'
+  spec.add_dependency 'resque', '>= 1'
 
   spec.add_development_dependency 'bundler', '~> 1.13'
   spec.add_development_dependency 'rake', '~> 12.0'

--- a/lib/cloud_watch_metrics/resque/version.rb
+++ b/lib/cloud_watch_metrics/resque/version.rb
@@ -2,6 +2,6 @@
 
 module CloudWatchMetrics
   class Resque
-    VERSION = '0.5.0'
+    VERSION = '0.5.1'
   end
 end


### PR DESCRIPTION
Resque 2 has recently been released and we'd like to upgrade to it to get rid of a bunch of annoying deprecation warnings in logs.

We've tested this change with resque 2 and metrics are still successfully being sent through to cloudwatch.

